### PR TITLE
Refactors command and query handling

### DIFF
--- a/MyDotNetBase/MyDotNetBase.Api/Abstractions/ApiController.cs
+++ b/MyDotNetBase/MyDotNetBase.Api/Abstractions/ApiController.cs
@@ -1,5 +1,5 @@
 ﻿using MyDotNetBase.Application.Abstractions.Messaging;
-using MyDotNetBase.Domain.Shared.Entities;
+using MyDotNetBase.Domain.Shared.Results;
 
 namespace MyDotNetBase.Api.Abstractions;
 

--- a/MyDotNetBase/MyDotNetBase.Api/Controllers/IdentityController.cs
+++ b/MyDotNetBase/MyDotNetBase.Api/Controllers/IdentityController.cs
@@ -7,27 +7,27 @@ namespace MyDotNetBase.Api.Controllers;
 public class IdentityController(ISender sender) : ApiController(sender)
 {
     [HttpPost("login")]
-    public async Task<IActionResult> Login(
+    public Task<IActionResult> Login(
         [FromBody] LoginRequest request,
         CancellationToken cancellationToken)
     {
         var command = new LoginCommand(
             request.Username,
             request.Password);
-        return await SendCommandAsync(command, cancellationToken);
+        return SendCommandAsync(command, cancellationToken);
     }
 
     [HttpPost("refresh-token")]
-    public async Task<IActionResult> RefreshToken(
+    public Task<IActionResult> RefreshToken(
         [FromBody] RefreshTokenRequest request,
         CancellationToken cancellationToken)
     {
         var command = new RefreshTokenCommand(request.RefreshToken);
-        return await SendCommandAsync(command, cancellationToken);
+        return SendCommandAsync(command, cancellationToken);
     }
 
     [HttpPost("register")]
-    public async Task<IActionResult> RegisterUser(
+    public Task<IActionResult> RegisterUser(
         [FromBody] RegisterUserRequest request,
         CancellationToken cancellationToken)
     {
@@ -35,6 +35,6 @@ public class IdentityController(ISender sender) : ApiController(sender)
             request.Email,
             request.FullName,
             request.Password);
-        return await SendCommandAsync(command, cancellationToken);
+        return SendCommandAsync(command, cancellationToken);
     }
 }

--- a/MyDotNetBase/MyDotNetBase.Api/Controllers/RolesController.cs
+++ b/MyDotNetBase/MyDotNetBase.Api/Controllers/RolesController.cs
@@ -1,5 +1,6 @@
 ﻿using MyDotNetBase.Api.Contracts.Role;
 using MyDotNetBase.Application.Roles.Commands;
+using MyDotNetBase.Application.Roles.Queries;
 
 namespace MyDotNetBase.Api.Controllers;
 
@@ -7,7 +8,7 @@ namespace MyDotNetBase.Api.Controllers;
 public class RolesController(ISender sender) : ApiController(sender)
 {
     [HttpPost]
-    public async Task<IActionResult> Create(
+    public Task<IActionResult> Create(
         [FromBody] CreateRoleRequest request,
         CancellationToken cancellationToken)
     {
@@ -15,11 +16,11 @@ public class RolesController(ISender sender) : ApiController(sender)
             request.Name,
             request.Description,
             request.Permissions);
-        return await SendCommandAsync(command, cancellationToken);
+        return SendCommandAsync(command, cancellationToken);
     }
 
     [HttpPut]
-    public async Task<IActionResult> Update(
+    public Task<IActionResult> Update(
         [FromBody] UpdateRoleRequest request,
         CancellationToken cancellationToken)
     {
@@ -28,15 +29,22 @@ public class RolesController(ISender sender) : ApiController(sender)
             request.Name,
             request.Description,
             request.Permissions);
-        return await SendCommandAsync(command, cancellationToken);
+        return SendCommandAsync(command, cancellationToken);
     }
 
     [HttpDelete("{roleId}")]
-    public async Task<IActionResult> Delete(
+    public Task<IActionResult> Delete(
         [FromRoute] string roleId,
         CancellationToken cancellationToken)
     {
         var command = new DeleteRoleCommand(roleId);
-        return await SendCommandAsync(command, cancellationToken);
+        return SendCommandAsync(command, cancellationToken);
+    }
+
+    [HttpGet("permissions")]
+    public Task<IActionResult> GetPermissions(CancellationToken cancellationToken)
+    {
+        var query = new GetAllPermissionsQuery();
+        return SendQueryAsync(query, cancellationToken);
     }
 }

--- a/MyDotNetBase/MyDotNetBase.Api/Controllers/UsersController.cs
+++ b/MyDotNetBase/MyDotNetBase.Api/Controllers/UsersController.cs
@@ -6,11 +6,11 @@ namespace MyDotNetBase.Api.Controllers;
 public sealed class UsersController(ISender sender) : ApiController(sender)
 {
     [HttpGet("{userId}")]
-    public async Task<IActionResult> GetUserById(
+    public Task<IActionResult> GetUserById(
         [FromRoute] string userId,
         CancellationToken cancellationToken)
     {
         var query = new GetUserByIdQuery(userId);
-        return await SendQueryAsync(query, cancellationToken);
+        return SendQueryAsync(query, cancellationToken);
     }
 }

--- a/MyDotNetBase/MyDotNetBase.Application/Abstractions/Data/IRepository.cs
+++ b/MyDotNetBase/MyDotNetBase.Application/Abstractions/Data/IRepository.cs
@@ -1,4 +1,4 @@
-﻿using MyDotNetBase.Domain.Shared.Aggregates;
+﻿using MyDotNetBase.Domain.Shared.Abstractions;
 
 namespace MyDotNetBase.Application.Abstractions.Data;
 

--- a/MyDotNetBase/MyDotNetBase.Application/Abstractions/Messaging/ICommand.cs
+++ b/MyDotNetBase/MyDotNetBase.Application/Abstractions/Messaging/ICommand.cs
@@ -1,4 +1,6 @@
-﻿namespace MyDotNetBase.Application.Abstractions.Messaging;
+﻿using MyDotNetBase.Domain.Shared.Results;
+
+namespace MyDotNetBase.Application.Abstractions.Messaging;
 
 public interface ICommand : IRequest<Result>;
 

--- a/MyDotNetBase/MyDotNetBase.Application/Abstractions/Messaging/ICommandHandler.cs
+++ b/MyDotNetBase/MyDotNetBase.Application/Abstractions/Messaging/ICommandHandler.cs
@@ -1,4 +1,6 @@
-﻿namespace MyDotNetBase.Application.Abstractions.Messaging;
+﻿using MyDotNetBase.Domain.Shared.Results;
+
+namespace MyDotNetBase.Application.Abstractions.Messaging;
 
 public interface ICommandHandler<in TCommand> : IRequestHandler<TCommand, Result>
     where TCommand : ICommand;

--- a/MyDotNetBase/MyDotNetBase.Application/Abstractions/Messaging/IQuery.cs
+++ b/MyDotNetBase/MyDotNetBase.Application/Abstractions/Messaging/IQuery.cs
@@ -1,3 +1,5 @@
-﻿namespace MyDotNetBase.Application.Abstractions.Messaging;
+﻿using MyDotNetBase.Domain.Shared.Results;
+
+namespace MyDotNetBase.Application.Abstractions.Messaging;
 
 public interface IQuery<TResponse> : IRequest<Result<TResponse>>;

--- a/MyDotNetBase/MyDotNetBase.Application/Abstractions/Messaging/IQueryHandler.cs
+++ b/MyDotNetBase/MyDotNetBase.Application/Abstractions/Messaging/IQueryHandler.cs
@@ -1,4 +1,6 @@
-﻿namespace MyDotNetBase.Application.Abstractions.Messaging;
+﻿using MyDotNetBase.Domain.Shared.Results;
+
+namespace MyDotNetBase.Application.Abstractions.Messaging;
 
 public interface IQueryHandler<in TQuery, TResponse> : IRequestHandler<TQuery, Result<TResponse>>
     where TQuery : IQuery<TResponse>;

--- a/MyDotNetBase/MyDotNetBase.Application/Behaviors/RequestLoggingPipelineBahavior.cs
+++ b/MyDotNetBase/MyDotNetBase.Application/Behaviors/RequestLoggingPipelineBahavior.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using MediatR;
 using Microsoft.Extensions.Logging;
+using MyDotNetBase.Domain.Shared.Results;
 using Serilog.Context;
 
 namespace MyDotNetBase.Application.Behaviors

--- a/MyDotNetBase/MyDotNetBase.Application/Behaviors/ValidationPipelineBehavior.cs
+++ b/MyDotNetBase/MyDotNetBase.Application/Behaviors/ValidationPipelineBehavior.cs
@@ -1,4 +1,6 @@
-﻿namespace MyDotNetBase.Application.Behaviors;
+﻿using MyDotNetBase.Domain.Shared.Results;
+
+namespace MyDotNetBase.Application.Behaviors;
 
 public class ValidationPipelineBehavior<TRequest, TResponse>
     : IPipelineBehavior<TRequest, TResponse>

--- a/MyDotNetBase/MyDotNetBase.Application/GlobalUsing.cs
+++ b/MyDotNetBase/MyDotNetBase.Application/GlobalUsing.cs
@@ -1,5 +1,5 @@
 ﻿global using MediatR;
 global using FluentValidation;
-global using MyDotNetBase.Domain.Shared.Entities;
+global using MyDotNetBase.Domain.Shared.Results;
 global using MyDotNetBase.Application.Abstractions.Messaging;
 global using MyDotNetBase.Application.Abstractions.Data;

--- a/MyDotNetBase/MyDotNetBase.Application/Identity/Commands/LoginCommand.cs
+++ b/MyDotNetBase/MyDotNetBase.Application/Identity/Commands/LoginCommand.cs
@@ -2,6 +2,7 @@
 using MyDotNetBase.Application.Abstractions.Data;
 using MyDotNetBase.Domain.Identity.Entities;
 using MyDotNetBase.Domain.Identity.Errors;
+using MyDotNetBase.Domain.Shared.Results;
 using MyDotNetBase.Domain.Users.Errors;
 
 namespace MyDotNetBase.Application.Identity.Commands;

--- a/MyDotNetBase/MyDotNetBase.Application/Identity/Commands/RefreshTokenCommand.cs
+++ b/MyDotNetBase/MyDotNetBase.Application/Identity/Commands/RefreshTokenCommand.cs
@@ -1,5 +1,6 @@
 ﻿using MyDotNetBase.Application.Abstractions.Authentication;
 using MyDotNetBase.Domain.Identity.Errors;
+using MyDotNetBase.Domain.Shared.Results;
 
 namespace MyDotNetBase.Application.Identity.Commands;
 

--- a/MyDotNetBase/MyDotNetBase.Application/Identity/Commands/RegisterUserCommand.cs
+++ b/MyDotNetBase/MyDotNetBase.Application/Identity/Commands/RegisterUserCommand.cs
@@ -1,4 +1,5 @@
 ﻿using MyDotNetBase.Application.Abstractions.Authentication;
+using MyDotNetBase.Domain.Shared.Results;
 using MyDotNetBase.Domain.Users.Entities;
 using MyDotNetBase.Domain.Users.Services;
 

--- a/MyDotNetBase/MyDotNetBase.Application/Roles/Commands/CreateRoleCommand.cs
+++ b/MyDotNetBase/MyDotNetBase.Application/Roles/Commands/CreateRoleCommand.cs
@@ -1,5 +1,6 @@
 ﻿using MyDotNetBase.Domain.Roles.Entities;
 using MyDotNetBase.Domain.Roles.Enums;
+using MyDotNetBase.Domain.Shared.Results;
 
 namespace MyDotNetBase.Application.Roles.Commands;
 

--- a/MyDotNetBase/MyDotNetBase.Application/Roles/Commands/RemoveRoleCommand.cs
+++ b/MyDotNetBase/MyDotNetBase.Application/Roles/Commands/RemoveRoleCommand.cs
@@ -1,6 +1,7 @@
 ﻿
 using MyDotNetBase.Domain.Roles.Errors;
 using MyDotNetBase.Domain.Roles.ValueObjects;
+using MyDotNetBase.Domain.Shared.Results;
 
 namespace MyDotNetBase.Application.Roles.Commands;
 

--- a/MyDotNetBase/MyDotNetBase.Application/Roles/Commands/UpdateRoleCommand.cs
+++ b/MyDotNetBase/MyDotNetBase.Application/Roles/Commands/UpdateRoleCommand.cs
@@ -2,6 +2,7 @@
 using MyDotNetBase.Domain.Roles.Enums;
 using MyDotNetBase.Domain.Roles.Errors;
 using MyDotNetBase.Domain.Roles.ValueObjects;
+using MyDotNetBase.Domain.Shared.Results;
 
 namespace MyDotNetBase.Application.Roles.Commands;
 

--- a/MyDotNetBase/MyDotNetBase.Application/Roles/Queries/GetAllPermissionsQuery.cs
+++ b/MyDotNetBase/MyDotNetBase.Application/Roles/Queries/GetAllPermissionsQuery.cs
@@ -1,0 +1,24 @@
+﻿using MyDotNetBase.Domain.Roles.Enums;
+using MyDotNetBase.Domain.Shared.Results;
+using MyDotNetBase.Domain.Shared.Utilities;
+
+namespace MyDotNetBase.Application.Roles.Queries;
+
+public sealed record GetAllPermissionsQuery() : IQuery<GetAllPermissionsQueryResult>;
+public sealed record PermissionResponse(string Value, string Description);
+public sealed record GetAllPermissionsQueryResult(List<PermissionResponse> Permissions);
+
+public sealed class GetAllPermissionsQueryHandler :
+    IQueryHandler<GetAllPermissionsQuery, GetAllPermissionsQueryResult>
+{
+    public Task<Result<GetAllPermissionsQueryResult>> Handle(
+        GetAllPermissionsQuery request,
+        CancellationToken cancellationToken)
+    {
+        var permissions = Enum.GetValues<Permission>()
+            .Select(p => new PermissionResponse(p.ToString(), p.GetDescription()))
+            .ToList();
+        var result = new GetAllPermissionsQueryResult(permissions);
+        return Task.FromResult(Result.Success(result));
+    }
+}

--- a/MyDotNetBase/MyDotNetBase.Application/Users/Queries/GetUserByIdQuery.cs
+++ b/MyDotNetBase/MyDotNetBase.Application/Users/Queries/GetUserByIdQuery.cs
@@ -1,4 +1,5 @@
-﻿using MyDotNetBase.Domain.Users.Entities;
+﻿using MyDotNetBase.Domain.Shared.Results;
+using MyDotNetBase.Domain.Users.Entities;
 using MyDotNetBase.Domain.Users.ValueObjects;
 
 namespace MyDotNetBase.Application.Users.Queries;

--- a/MyDotNetBase/MyDotNetBase.Domain/Identity/Entities/RefreshToken.cs
+++ b/MyDotNetBase/MyDotNetBase.Domain/Identity/Entities/RefreshToken.cs
@@ -1,4 +1,4 @@
-﻿using MyDotNetBase.Domain.Shared.Aggregates;
+﻿using MyDotNetBase.Domain.Shared.Abstractions;
 using MyDotNetBase.Domain.Users.Entities;
 using MyDotNetBase.Domain.Users.ValueObjects;
 

--- a/MyDotNetBase/MyDotNetBase.Domain/Identity/Errors/IdentityErrors.cs
+++ b/MyDotNetBase/MyDotNetBase.Domain/Identity/Errors/IdentityErrors.cs
@@ -1,4 +1,4 @@
-﻿using MyDotNetBase.Domain.Shared.Entities;
+﻿using MyDotNetBase.Domain.Shared.Results;
 
 namespace MyDotNetBase.Domain.Identity.Errors;
 

--- a/MyDotNetBase/MyDotNetBase.Domain/Roles/Entities/Role.cs
+++ b/MyDotNetBase/MyDotNetBase.Domain/Roles/Entities/Role.cs
@@ -1,8 +1,8 @@
 ﻿using MyDotNetBase.Domain.Roles.Enums;
 using MyDotNetBase.Domain.Roles.Errors;
 using MyDotNetBase.Domain.Roles.ValueObjects;
-using MyDotNetBase.Domain.Shared.Aggregates;
-using MyDotNetBase.Domain.Shared.Entities;
+using MyDotNetBase.Domain.Shared.Abstractions;
+using MyDotNetBase.Domain.Shared.Results;
 
 namespace MyDotNetBase.Domain.Roles.Entities;
 

--- a/MyDotNetBase/MyDotNetBase.Domain/Roles/Errors/PermissionErrors.cs
+++ b/MyDotNetBase/MyDotNetBase.Domain/Roles/Errors/PermissionErrors.cs
@@ -1,4 +1,4 @@
-﻿using MyDotNetBase.Domain.Shared.Entities;
+﻿using MyDotNetBase.Domain.Shared.Results;
 
 namespace MyDotNetBase.Domain.Roles.Errors;
 

--- a/MyDotNetBase/MyDotNetBase.Domain/Roles/Errors/RoleErrors.cs
+++ b/MyDotNetBase/MyDotNetBase.Domain/Roles/Errors/RoleErrors.cs
@@ -1,4 +1,4 @@
-﻿using MyDotNetBase.Domain.Shared.Entities;
+﻿using MyDotNetBase.Domain.Shared.Results;
 
 namespace MyDotNetBase.Domain.Roles.Errors;
 public class RoleErrors

--- a/MyDotNetBase/MyDotNetBase.Domain/Roles/ValueObjects/RolePermission.cs
+++ b/MyDotNetBase/MyDotNetBase.Domain/Roles/ValueObjects/RolePermission.cs
@@ -1,6 +1,6 @@
 ﻿using MyDotNetBase.Domain.Roles.Enums;
 using MyDotNetBase.Domain.Roles.Errors;
-using MyDotNetBase.Domain.Shared.Entities;
+using MyDotNetBase.Domain.Shared.Results;
 
 namespace MyDotNetBase.Domain.Roles.ValueObjects;
 

--- a/MyDotNetBase/MyDotNetBase.Domain/Shared/Abstractions/AggregateRoot.cs
+++ b/MyDotNetBase/MyDotNetBase.Domain/Shared/Abstractions/AggregateRoot.cs
@@ -1,9 +1,4 @@
-﻿using MyDotNetBase.Domain.Shared.Auditing;
-using MyDotNetBase.Domain.Shared.DomainEvents;
-using MyDotNetBase.Domain.Shared.Entities;
-using MyDotNetBase.Domain.Shared.SoftDelete;
-
-namespace MyDotNetBase.Domain.Shared.Aggregates;
+﻿namespace MyDotNetBase.Domain.Shared.Abstractions;
 
 public abstract class AggregateRoot<TId> :
     Entity<TId>,

--- a/MyDotNetBase/MyDotNetBase.Domain/Shared/Abstractions/DomainEventBase.cs
+++ b/MyDotNetBase/MyDotNetBase.Domain/Shared/Abstractions/DomainEventBase.cs
@@ -1,4 +1,4 @@
-﻿namespace MyDotNetBase.Domain.Shared.DomainEvents;
+﻿namespace MyDotNetBase.Domain.Shared.Abstractions;
 
 public abstract record DomainEventBase : IDomainEvent
 {

--- a/MyDotNetBase/MyDotNetBase.Domain/Shared/Abstractions/Entity.cs
+++ b/MyDotNetBase/MyDotNetBase.Domain/Shared/Abstractions/Entity.cs
@@ -1,4 +1,4 @@
-﻿namespace MyDotNetBase.Domain.Shared.Entities;
+﻿namespace MyDotNetBase.Domain.Shared.Abstractions;
 
 public abstract class Entity<TId> where TId : notnull
 {

--- a/MyDotNetBase/MyDotNetBase.Domain/Shared/Abstractions/IAuditable.cs
+++ b/MyDotNetBase/MyDotNetBase.Domain/Shared/Abstractions/IAuditable.cs
@@ -1,4 +1,4 @@
-﻿namespace MyDotNetBase.Domain.Shared.Auditing;
+﻿namespace MyDotNetBase.Domain.Shared.Abstractions;
 
 public interface IAuditable
 {

--- a/MyDotNetBase/MyDotNetBase.Domain/Shared/Abstractions/IDomainEvent.cs
+++ b/MyDotNetBase/MyDotNetBase.Domain/Shared/Abstractions/IDomainEvent.cs
@@ -1,6 +1,6 @@
 ﻿using MediatR;
 
-namespace MyDotNetBase.Domain.Shared.DomainEvents;
+namespace MyDotNetBase.Domain.Shared.Abstractions;
 public interface IDomainEvent : INotification
 {
     DateTime OccurredOn { get; }

--- a/MyDotNetBase/MyDotNetBase.Domain/Shared/Abstractions/IHasDomainEvents.cs
+++ b/MyDotNetBase/MyDotNetBase.Domain/Shared/Abstractions/IHasDomainEvents.cs
@@ -1,4 +1,4 @@
-﻿namespace MyDotNetBase.Domain.Shared.DomainEvents;
+﻿namespace MyDotNetBase.Domain.Shared.Abstractions;
 
 public interface IHasDomainEvents
 {

--- a/MyDotNetBase/MyDotNetBase.Domain/Shared/Abstractions/ISoftDeletable.cs
+++ b/MyDotNetBase/MyDotNetBase.Domain/Shared/Abstractions/ISoftDeletable.cs
@@ -1,4 +1,4 @@
-﻿namespace MyDotNetBase.Domain.Shared.SoftDelete;
+﻿namespace MyDotNetBase.Domain.Shared.Abstractions;
 
 public interface ISoftDeletable
 {

--- a/MyDotNetBase/MyDotNetBase.Domain/Shared/Results/Error.cs
+++ b/MyDotNetBase/MyDotNetBase.Domain/Shared/Results/Error.cs
@@ -1,4 +1,4 @@
-﻿namespace MyDotNetBase.Domain.Shared.Entities;
+﻿namespace MyDotNetBase.Domain.Shared.Results;
 
 public record Error
 {

--- a/MyDotNetBase/MyDotNetBase.Domain/Shared/Results/Result.cs
+++ b/MyDotNetBase/MyDotNetBase.Domain/Shared/Results/Result.cs
@@ -1,6 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 
-namespace MyDotNetBase.Domain.Shared.Entities;
+namespace MyDotNetBase.Domain.Shared.Results;
 
 public class Result
 {

--- a/MyDotNetBase/MyDotNetBase.Domain/Shared/Results/ValidationError.cs
+++ b/MyDotNetBase/MyDotNetBase.Domain/Shared/Results/ValidationError.cs
@@ -1,4 +1,4 @@
-﻿namespace MyDotNetBase.Domain.Shared.Entities;
+﻿namespace MyDotNetBase.Domain.Shared.Results;
 
 public sealed record ValidationError : Error
 {

--- a/MyDotNetBase/MyDotNetBase.Domain/Shared/Utilities/EnumExtensions.cs
+++ b/MyDotNetBase/MyDotNetBase.Domain/Shared/Utilities/EnumExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel;
+using System.Reflection;
+
+namespace MyDotNetBase.Domain.Shared.Utilities;
+
+public static class EnumExtensions
+{
+    public static string GetDescription<TEnum>(this TEnum value) where TEnum : struct, Enum
+    {
+        var fieldInfo = typeof(TEnum).GetField(value.ToString());
+        return fieldInfo?
+            .GetCustomAttribute<DescriptionAttribute>(false)?
+            .Description ?? value.ToString();
+    }
+}

--- a/MyDotNetBase/MyDotNetBase.Domain/Users/Entities/User.cs
+++ b/MyDotNetBase/MyDotNetBase.Domain/Users/Entities/User.cs
@@ -1,6 +1,6 @@
 ﻿using MyDotNetBase.Domain.Roles.Entities;
-using MyDotNetBase.Domain.Shared.Aggregates;
-using MyDotNetBase.Domain.Shared.Entities;
+using MyDotNetBase.Domain.Shared.Abstractions;
+using MyDotNetBase.Domain.Shared.Results;
 using MyDotNetBase.Domain.Users.Errors;
 using MyDotNetBase.Domain.Users.Events;
 using MyDotNetBase.Domain.Users.Services;

--- a/MyDotNetBase/MyDotNetBase.Domain/Users/Errors/EmailErrors.cs
+++ b/MyDotNetBase/MyDotNetBase.Domain/Users/Errors/EmailErrors.cs
@@ -1,4 +1,4 @@
-﻿using MyDotNetBase.Domain.Shared.Entities;
+﻿using MyDotNetBase.Domain.Shared.Results;
 
 namespace MyDotNetBase.Domain.Users.Errors;
 

--- a/MyDotNetBase/MyDotNetBase.Domain/Users/Errors/UserErrors.cs
+++ b/MyDotNetBase/MyDotNetBase.Domain/Users/Errors/UserErrors.cs
@@ -1,4 +1,4 @@
-﻿using MyDotNetBase.Domain.Shared.Entities;
+﻿using MyDotNetBase.Domain.Shared.Results;
 using MyDotNetBase.Domain.Users.ValueObjects;
 
 namespace MyDotNetBase.Domain.Users.Errors;

--- a/MyDotNetBase/MyDotNetBase.Domain/Users/Events/UserRegisteredDomainEvent.cs
+++ b/MyDotNetBase/MyDotNetBase.Domain/Users/Events/UserRegisteredDomainEvent.cs
@@ -1,4 +1,4 @@
-﻿using MyDotNetBase.Domain.Shared.DomainEvents;
+﻿using MyDotNetBase.Domain.Shared.Abstractions;
 using MyDotNetBase.Domain.Users.ValueObjects;
 
 namespace MyDotNetBase.Domain.Users.Events;

--- a/MyDotNetBase/MyDotNetBase.Domain/Users/ValueObjects/Email.cs
+++ b/MyDotNetBase/MyDotNetBase.Domain/Users/ValueObjects/Email.cs
@@ -1,4 +1,4 @@
-﻿using MyDotNetBase.Domain.Shared.Entities;
+﻿using MyDotNetBase.Domain.Shared.Results;
 using MyDotNetBase.Domain.Users.Errors;
 using System.Net.Mail;
 

--- a/MyDotNetBase/MyDotNetBase.Infrastructure/Outbox/ProcessOutboxMessagesJob.cs
+++ b/MyDotNetBase/MyDotNetBase.Infrastructure/Outbox/ProcessOutboxMessagesJob.cs
@@ -1,6 +1,6 @@
 ﻿using MediatR;
 using Microsoft.Extensions.Logging;
-using MyDotNetBase.Domain.Shared.DomainEvents;
+using MyDotNetBase.Domain.Shared.Abstractions;
 using MyDotNetBase.Infrastructure.Persistence;
 using Newtonsoft.Json;
 using Quartz;

--- a/MyDotNetBase/MyDotNetBase.Infrastructure/Persistence/Interceptors/AuditSaveChangesInterceptor.cs
+++ b/MyDotNetBase/MyDotNetBase.Infrastructure/Persistence/Interceptors/AuditSaveChangesInterceptor.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore.Diagnostics;
 using MyDotNetBase.Application.Abstractions.Authentication;
-using MyDotNetBase.Domain.Shared.Auditing;
+using MyDotNetBase.Domain.Shared.Abstractions;
 
 namespace MyDotNetBase.Infrastructure.Persistence.Interceptors;
 

--- a/MyDotNetBase/MyDotNetBase.Infrastructure/Persistence/Interceptors/ConvertDomainEventsToOutboxMessageInterceptor.cs
+++ b/MyDotNetBase/MyDotNetBase.Infrastructure/Persistence/Interceptors/ConvertDomainEventsToOutboxMessageInterceptor.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore.Diagnostics;
-using MyDotNetBase.Domain.Shared.DomainEvents;
+using MyDotNetBase.Domain.Shared.Abstractions;
 using MyDotNetBase.Infrastructure.Outbox;
 using Newtonsoft.Json;
 

--- a/MyDotNetBase/MyDotNetBase.Infrastructure/Persistence/Interceptors/SoftDeleteSaveChangesInterceptor.cs
+++ b/MyDotNetBase/MyDotNetBase.Infrastructure/Persistence/Interceptors/SoftDeleteSaveChangesInterceptor.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore.Diagnostics;
-using MyDotNetBase.Domain.Shared.SoftDelete;
+using MyDotNetBase.Domain.Shared.Abstractions;
 
 namespace MyDotNetBase.Infrastructure.Persistence.Interceptors;
 

--- a/MyDotNetBase/MyDotNetBase.Infrastructure/Persistence/Repositories/Repository.cs
+++ b/MyDotNetBase/MyDotNetBase.Infrastructure/Persistence/Repositories/Repository.cs
@@ -1,4 +1,4 @@
-﻿using MyDotNetBase.Domain.Shared.Aggregates;
+﻿using MyDotNetBase.Domain.Shared.Abstractions;
 
 namespace MyDotNetBase.Infrastructure.Persistence.Repositories;
 

--- a/MyDotNetBase/MyDotNetBase.Infrastructure/Persistence/Repositories/UserRepository.cs
+++ b/MyDotNetBase/MyDotNetBase.Infrastructure/Persistence/Repositories/UserRepository.cs
@@ -4,7 +4,7 @@ using MyDotNetBase.Domain.Users.ValueObjects;
 
 namespace MyDotNetBase.Infrastructure.Persistence.Repositories;
 
-public sealed class UserRepository(ApplicationDbContext context) : 
+public sealed class UserRepository(ApplicationDbContext context) :
     Repository<User, UserId>(context),
     IUserRepository
 {


### PR DESCRIPTION
Simplifies API controller actions to return Task directly.
This change streamlines command and query execution by removing the explicit 'await' keyword in the controller, leveraging the existing asynchronous handling within the SendCommandAsync and SendQueryAsync methods.
It also includes creating ICommand and IQuery interfaces in Abstractions/Messaging folder and refactoring domain entities.
Finally adds a GetPermissions endpoint to RolesController to get all available permissions.
